### PR TITLE
Fix/1 상점 등록시 파트너 테이블에 id 값이 증가되는 이슈

### DIFF
--- a/src/main/java/livoi/reservation/ReservationProjectApplication.java
+++ b/src/main/java/livoi/reservation/ReservationProjectApplication.java
@@ -2,10 +2,8 @@ package livoi.reservation;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 @SpringBootApplication
-@EntityScan(basePackages = "livoi.reservation.model.entity")
 public class ReservationProjectApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/livoi/reservation/controller/MemberController.java
+++ b/src/main/java/livoi/reservation/controller/MemberController.java
@@ -1,6 +1,6 @@
 package livoi.reservation.controller;
 
-import livoi.reservation.model.entity.AuthEntity;
+import livoi.reservation.dto.AuthUserRequest;
 import livoi.reservation.security.TokenProvider;
 import livoi.reservation.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collections;
 
 @Slf4j
 @RestController
@@ -22,15 +24,15 @@ public class MemberController {
     private final TokenProvider tokenProvider;
 
     @PostMapping("/auth/signup")
-    public ResponseEntity<?> signup(@RequestBody AuthEntity.signUp request){
+    public ResponseEntity<?> signup(@RequestBody AuthUserRequest.signUp request){
         var result = this.memberService.registerMember(request);
         return ResponseEntity.ok(result);
     }
 
     @PostMapping("/auth/signin")
-    public ResponseEntity<?> signin(@RequestBody AuthEntity.signIn request){
+    public ResponseEntity<?> signin(@RequestBody AuthUserRequest.signIn request){
         var member = this.memberService.authenticate(request);
-        var token = this.tokenProvider.generateToken(member.getUsername(), member.getRoles());
+        var token = this.tokenProvider.generateToken(member.getUsername(), Collections.singletonList(member.getRole()));
 
         return ResponseEntity.ok(token);
     }

--- a/src/main/java/livoi/reservation/controller/PartnerController.java
+++ b/src/main/java/livoi/reservation/controller/PartnerController.java
@@ -1,6 +1,6 @@
 package livoi.reservation.controller;
 
-import livoi.reservation.model.entity.AuthEntity;
+import livoi.reservation.dto.AuthUserRequest;
 import livoi.reservation.security.TokenProvider;
 import livoi.reservation.service.PartnerService;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collections;
 
 @Slf4j
 @RestController
@@ -21,15 +23,15 @@ public class PartnerController {
     private final TokenProvider tokenProvider;
 
     @PostMapping("/auth/signup")
-    public ResponseEntity<?> signup(@RequestBody AuthEntity.signUp request){
+    public ResponseEntity<?> signup(@RequestBody AuthUserRequest.signUp request){
         var result = this.partnerService.registerPartner(request);
         return ResponseEntity.ok(result);
     }
 
     @PostMapping("/auth/signin")
-    public ResponseEntity<?> signin(@RequestBody AuthEntity.signIn request){
+    public ResponseEntity<?> signin(@RequestBody AuthUserRequest.signIn request){
         var partner = this.partnerService.authenticate(request);
-        var token = this.tokenProvider.generateToken(partner.getUsername(), partner.getRoles());
+        var token = this.tokenProvider.generateToken(partner.getUsername(), Collections.singletonList(partner.getRole()));
 
         return ResponseEntity.ok(token);
     }

--- a/src/main/java/livoi/reservation/controller/UserController.java
+++ b/src/main/java/livoi/reservation/controller/UserController.java
@@ -1,2 +1,0 @@
-package livoi.reservation.controller;public class UserController {
-}

--- a/src/main/java/livoi/reservation/domain/MemberEntity.java
+++ b/src/main/java/livoi/reservation/domain/MemberEntity.java
@@ -1,14 +1,16 @@
-package livoi.reservation.model.entity;
+package livoi.reservation.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * 예약 시스템의 사용자를 나타내는 클래스.
@@ -36,8 +38,7 @@ public class MemberEntity implements UserDetails {
 
     private String userPwd;
 
-    @ElementCollection(fetch = FetchType.EAGER)
-    private List<String> roles;
+    private String role;
 
     /**
      * 사용자에게 부여된 권한을 반환. 이 메서드는 UserDetails 인터페이스의 일부.
@@ -47,7 +48,7 @@ public class MemberEntity implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return this.roles.stream()
+        return Stream.of(role.split(","))
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/livoi/reservation/domain/PartnerEntity.java
+++ b/src/main/java/livoi/reservation/domain/PartnerEntity.java
@@ -1,4 +1,4 @@
-package livoi.reservation.model.entity;
+package livoi.reservation.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
@@ -7,8 +7,8 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Builder
 @Getter
@@ -34,15 +34,12 @@ public class PartnerEntity implements UserDetails {
     @Column(name = "partner_pwd")
     private String partnerPwd;
 
-    @OneToMany(mappedBy = "partner")
-    private List<ShopEntity> shops;
-
-    @ElementCollection(fetch = FetchType.EAGER)
-    private List<String> roles;
+    @Column(name = "role")
+    private String role;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return this.roles.stream()
+        return Stream.of(role.split(","))
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/livoi/reservation/dto/AuthUserRequest.java
+++ b/src/main/java/livoi/reservation/dto/AuthUserRequest.java
@@ -1,10 +1,10 @@
-package livoi.reservation.model.entity;
+package livoi.reservation.dto;
 
+import livoi.reservation.domain.MemberEntity;
+import livoi.reservation.domain.PartnerEntity;
 import lombok.Data;
 
-import java.util.List;
-
-public class AuthEntity {
+public class AuthUserRequest {
 
 
     @Data
@@ -18,14 +18,14 @@ public class AuthEntity {
     public static class signUp {
         private String username;
         private String password;
-        private List<String> roles;
+        private String role;
 
         // SignUp 객체 -> MemberEntity 객체로 변환
         public MemberEntity toMemberEntity() {
             return MemberEntity.builder()
                     .userId(this.username)
                     .userPwd(this.password)
-                    .roles(this.roles)
+                    .role(this.role)
                     .build();
         }
 
@@ -34,7 +34,7 @@ public class AuthEntity {
             return PartnerEntity.builder()
                     .partnerId(this.username)
                     .partnerPwd(this.password)
-                    .roles(this.roles)
+                    .role(this.role)
                     .build();
         }
     }

--- a/src/main/java/livoi/reservation/model/constants/Authority.java
+++ b/src/main/java/livoi/reservation/model/constants/Authority.java
@@ -1,7 +1,0 @@
-package livoi.reservation.model.constants;
-
-public enum Authority {
-
-    ROLE_READ,
-    ROLE_WRITE;
-}

--- a/src/main/java/livoi/reservation/model/entity/UserEntity.java
+++ b/src/main/java/livoi/reservation/model/entity/UserEntity.java
@@ -1,4 +1,0 @@
-package livoi.reservation.model.repository;
-
-public class UserEntity {
-}

--- a/src/main/java/livoi/reservation/model/repository/UserRepository.java
+++ b/src/main/java/livoi/reservation/model/repository/UserRepository.java
@@ -1,2 +1,0 @@
-package livoi.reservation.model.repository;public class UserRepository {
-}

--- a/src/main/java/livoi/reservation/repository/MemberRepository.java
+++ b/src/main/java/livoi/reservation/repository/MemberRepository.java
@@ -1,6 +1,6 @@
-package livoi.reservation.model.repository;
+package livoi.reservation.repository;
 
-import livoi.reservation.model.entity.MemberEntity;
+import livoi.reservation.domain.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/livoi/reservation/service/MemberService.java
+++ b/src/main/java/livoi/reservation/service/MemberService.java
@@ -1,8 +1,8 @@
 package livoi.reservation.service;
 
-import livoi.reservation.model.entity.AuthEntity;
-import livoi.reservation.model.entity.MemberEntity;
-import livoi.reservation.model.repository.MemberRepository;
+import livoi.reservation.dto.AuthUserRequest;
+import livoi.reservation.domain.MemberEntity;
+import livoi.reservation.repository.MemberRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -32,7 +32,7 @@ public class MemberService implements UserDetailsService {
      * @param member AuthEntity.signUp의 인스턴스
      * @return 인코딩 한 값
      */
-    public MemberEntity registerMember(AuthEntity.signUp member){
+    public MemberEntity registerMember(AuthUserRequest.signUp member){
         boolean exists = this.memberRepository.existsByUserId(member.getUsername());
         if (exists){
             throw new RuntimeException("User name already exists.");
@@ -48,7 +48,7 @@ public class MemberService implements UserDetailsService {
      * @param member AuthEntity.signUp의 인스턴스
      * @return user
      */
-    public MemberEntity authenticate(AuthEntity.signIn member){
+    public MemberEntity authenticate(AuthUserRequest.signIn member){
         var user = this.memberRepository.findByUserId(member.getUsername())
                 .orElseThrow(() -> new RuntimeException("User name does not exists."));
 

--- a/src/main/java/livoi/reservation/service/PartnerService.java
+++ b/src/main/java/livoi/reservation/service/PartnerService.java
@@ -1,8 +1,8 @@
 package livoi.reservation.service;
 
-import livoi.reservation.model.entity.AuthEntity;
-import livoi.reservation.model.entity.PartnerEntity;
-import livoi.reservation.model.repository.PartnerRepository;
+import livoi.reservation.dto.AuthUserRequest;
+import livoi.reservation.domain.PartnerEntity;
+import livoi.reservation.repository.PartnerRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -32,7 +32,7 @@ public class PartnerService implements UserDetailsService {
      * @param partner AuthEntity.signUp의 인스턴스
      * @return 인코딩 한 값
      */
-    public PartnerEntity registerPartner(AuthEntity.signUp partner){
+    public PartnerEntity registerPartner(AuthUserRequest.signUp partner){
         boolean exists = this.partnerRepository.existsByPartnerId(partner.getUsername());
         if (exists){
             throw new RuntimeException("Partner name already exists.");
@@ -49,7 +49,7 @@ public class PartnerService implements UserDetailsService {
      * @param partner AuthEntity.signUp의 인스턴스
      * @return user
      */
-    public PartnerEntity authenticate(AuthEntity.signIn partner){
+    public PartnerEntity authenticate(AuthUserRequest.signIn partner){
         var user = this.partnerRepository.findByPartnerId(partner.getUsername())
                 .orElseThrow(() -> new RuntimeException("Partner name does not exists."));
 

--- a/src/main/java/livoi/reservation/type/Authority.java
+++ b/src/main/java/livoi/reservation/type/Authority.java
@@ -1,0 +1,7 @@
+package livoi.reservation.type;
+
+public enum Authority {
+
+    ROLE_READ,
+    ROLE_ADMIN;
+}


### PR DESCRIPTION
## Background
상점 등록시 파트너 테이블에 id 값이 증가되는 문제가 있었습니다. 파트너를 생성할때 올바르게 테이블에 권한 항목이 저장되지 않아 발생한 부분으로 엔티티와 서비스 로직을 수정했습니다.
 
## Changes
552a7fb7 상점기능에서 Partner만 상점을 등록하고 수정할 수 있도록 admin 권한을 부여하고 그 외에는 read권한만 부여했습니다.
dbcd79cf Partner 등록시 role 컬럼은 저장되고 있지 않아 저장되도록 권한도 저장될 수 있도록 했습니다.
b4f2fb0c 상점기능에서 사용자는 읽기권한만 필요해서 String으로 변경 했습니다.
c1edb3e0 entity 모두 프로젝트 내 존재해 entityScan 어노테이션 삭제 했습니다.
